### PR TITLE
Handle `messageHistory` not found case

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -135,7 +135,11 @@ class Ubiquity implements IUbiquity {
     const url = this.getUrl('messageHistory', true).replace('{{appUserId}}', sub);
     const resp = await fetch(url);
     if (!resp.ok) {
-      throw UbiquityError('Unable to retrieve the message history for the current user ', resp);
+      if(resp.status === 403){
+        return [];
+      } else {
+        throw UbiquityError('Unable to retrieve the message history for the current user ', resp);
+      }
     }
     return resp.json();
   }

--- a/src/client.ts
+++ b/src/client.ts
@@ -135,8 +135,8 @@ class Ubiquity implements IUbiquity {
     const url = this.getUrl('messageHistory', true).replace('{{appUserId}}', sub);
     const resp = await fetch(url);
     if (!resp.ok) {
-      if(resp.status === 403){
-        return [];
+      if(resp.status === 403) {
+        return { messages: [] };
       } else {
         throw UbiquityError('Unable to retrieve the message history for the current user ', resp);
       }


### PR DESCRIPTION
When a messageHistory object cannot be found in s3, it means that the user has no messages so return an empty array.